### PR TITLE
Added ignore parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/vbarzokas/greek-utils.svg?branch=master)](https://travis-ci.org/vbarzokas/greek-utils)
 
-A JavaScript library for Greek language with utilities such as replacement of accented and other diacritics characters, 
+A JavaScript library for Greek language with utilities such as replacement of accented and other diacritics characters,
 conversion from Greek to phonetic, transliterated or [greeklish](https://en.wikipedia.org/wiki/Greeklish) Latin and more.
 
 [![NPM](https://nodei.co/npm/greek-utils.png)](https://nodei.co/npm/greek-utils/)
@@ -69,4 +69,13 @@ Example:
 ```javascript
 var transliteratedLatin = greekUtils.toTransliteratedLatin('Εύηχο: αυτό που ακούγεται ωραία.');
 console.log(transliteratedLatin); //Eúēkho: autó pou akoúgetai ōraía.
+```
+
+#### Ignoring characters
+All functions accept an optional second parameter as a string with characters you don't wish to be converted.
+
+Example:
+```javascript
+var greeklish = greekUtils.toGreeklish('καλημερα, πως ειστε;', ';');
+console.log(greeklish); //kalhmera, pws eiste;
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,10 +19,11 @@ greekUtils = {
 	 * @method toGreek
 	 * @static
 	 * @param {String} text
+	 * @param {String} ignore
 	 * @returns {String}
 	 */
-	toGreek: function (text) {
-		return replaceText(text, greeklishToGreekMap, true);
+	toGreek: function (text, ignore) {
+		return replaceText(text, greeklishToGreekMap, true, ignore);
 	},
 
 	/**
@@ -31,10 +32,11 @@ greekUtils = {
 	 * @method toGreeklish
 	 * @static
 	 * @param {String} text
+	 * @param {String} ignore
 	 * @returns {String}
 	 */
-	toGreeklish: function (text) {
-		return replaceText(text, greekTogreeklishMap, true);
+	toGreeklish: function (text, ignore) {
+		return replaceText(text, greekTogreeklishMap, true, ignore);
 	},
 
 	/**
@@ -43,10 +45,11 @@ greekUtils = {
 	 * @method toPhoneticLatin
 	 * @static
 	 * @param {String} text
+	 * @param {String} ignore
 	 * @returns {String}
 	 */
-	toPhoneticLatin: function (text) {
-		return replaceText(text, greekToPhoneticLatinMap, true);
+	toPhoneticLatin: function (text, ignore) {
+		return replaceText(text, greekToPhoneticLatinMap, true, ignore);
 	},
 
 	/**
@@ -55,10 +58,11 @@ greekUtils = {
 	 * @method toTransliteratedLatin
 	 * @static
 	 * @param {String} text
+	 * @param {String} ignore
 	 * @returns {String}
 	 */
-	toTransliteratedLatin: function (text) {
-		return replaceText(text, greekToTransliteratedLatinMap, true);
+	toTransliteratedLatin: function (text, ignore) {
+		return replaceText(text, greekToTransliteratedLatinMap, true, ignore);
 	},
 
 	/**
@@ -67,10 +71,11 @@ greekUtils = {
 	 * @method sanitizeDiacritics
 	 * @static
 	 * @param {String} text
+	 * @param {String} ignore
 	 * @returns {String}
 	 */
-	sanitizeDiacritics: function (text) {
-		return replaceText(text, diacriticsMap, false);
+	sanitizeDiacritics: function (text, ignore) {
+		return replaceText(text, diacriticsMap, false, ignore);
 	}
 };
 
@@ -80,10 +85,13 @@ greekUtils = {
  * @param {String} text
  * @param {Array} characterMap
  * @param {Boolean} exactMatch
+ * @param {String} ignore
  * @returns {String}
  */
-function replaceText(text, characterMap, exactMatch) {
+function replaceText(text, characterMap, exactMatch, ignore) {
 	var characters,
+		find,
+		regexIgnore = new RegExp('[' + ignore + ']', 'g'),
 		regexString,
 		regex;
 
@@ -91,7 +99,9 @@ function replaceText(text, characterMap, exactMatch) {
 
 	if (typeof text === 'string' && text.length > 0) {
 		for (characters of characterMap) {
-			regexString = exactMatch ? characters.find : '[' + characters.find + ']';
+			find = characters.find.replace(regexIgnore, '');
+			if (!find) { continue; }
+			regexString = exactMatch ? find : '[' + find + ']';
 			regex = new RegExp(regexString, 'g');
 			text = text.replace(regex, characters.replace);
 		}

--- a/lib/index.js
+++ b/lib/index.js
@@ -90,8 +90,6 @@ greekUtils = {
  */
 function replaceText(text, characterMap, exactMatch, ignore) {
 	var characters,
-		find,
-		regexIgnore = new RegExp('[' + ignore + ']', 'g'),
 		regexString,
 		regex;
 
@@ -99,9 +97,8 @@ function replaceText(text, characterMap, exactMatch, ignore) {
 
 	if (typeof text === 'string' && text.length > 0) {
 		for (characters of characterMap) {
-			find = characters.find.replace(regexIgnore, '');
-			if (!find) { continue; }
-			regexString = exactMatch ? find : '[' + find + ']';
+			regexString = exactMatch ? characters.find : '[' + characters.find + ']';
+			if (ignore) { regexString = '(?![' + ignore + '])' + regexString; }
 			regex = new RegExp(regexString, 'g');
 			text = text.replace(regex, characters.replace);
 		}

--- a/test/lib/index.js
+++ b/test/lib/index.js
@@ -13,6 +13,8 @@ describe('Greek Utils:', function () {
 
 				assert.equal(greekUtils.toGreek('kalhmera, pws eiste?'), 'καλημερα, πως ειστε;');
 
+				assert.equal(greekUtils.toGreek('kalhmera, pws eiste?', '?p'), 'καλημερα, pως ειστε?');
+
 				done();
 			});
 		});
@@ -27,6 +29,8 @@ describe('Greek Utils:', function () {
 				assert.equal(greekUtils.toGreeklish('Εύηχο: αυτό που ακούγεται ωραία.'),
 					'Euhxo: auto pou akougetai wraia.');
 
+				assert.equal(greekUtils.toGreeklish('καλημερα, πως ειστε;', ';λ'), 'kaλhmera, pws eiste;');
+
 				done();
 			});
 		});
@@ -35,6 +39,9 @@ describe('Greek Utils:', function () {
 			it('Convert a modern Greek characters text to its phonetically equivalent Latin.', function (done) {
 				assert.equal(greekUtils.toPhoneticLatin('Εύηχο: αυτό που ακούγεται ωραία.'),
 					'Évikho: aftó pou akoúyete oréa.');
+
+				assert.equal(greekUtils.toPhoneticLatin('Εύηχο: αυτό που ακούγεται ωραία.', 'χ'),
+					'Éviχo: aftó pou akoúyete oréa.');
 
 				done();
 			});
@@ -45,6 +52,9 @@ describe('Greek Utils:', function () {
 				assert.equal(greekUtils.toTransliteratedLatin('Εύηχο: αυτό που ακούγεται ωραία.'),
 					'Eúēkho: autó pou akoúgetai ōraía.');
 
+				assert.equal(greekUtils.toTransliteratedLatin('Εύηχο: αυτό που ακούγεται ωραία.', 'αύ'),
+					'Eύēkho: αutó pou αkoύgetαi ōrαíα.');
+
 				done();
 			});
 		});
@@ -53,12 +63,17 @@ describe('Greek Utils:', function () {
 			it('converts a string of modern Greek characters with diacritics to their simple equivalent.', function (done) {
 				assert.equal(greekUtils.sanitizeDiacritics('Αρνάκι άσπρο και παχύ'), 'Αρνακι ασπρο και παχυ');
 
+				assert.equal(greekUtils.sanitizeDiacritics('Αρνάκι άσπρο και παχύ', 'άύ'), 'Αρνάκι άσπρο και παχύ');
+
 				done();
 			});
 
 			it('converts a string of ancient Greek characters with diacritics to their simple equivalent.', function (done) {
 				assert.equal(greekUtils.sanitizeDiacritics('Ἐξ οὗ καὶ δῆλον ὅτι οὐδεμία τῶν ἠθικῶν ἀρετῶν φύσει ἡμῖν ἐγγίνεται'),
 					'Εξ ου και δηλον οτι ουδεμια των ηθικων αρετων φυσει ημιν εγγινεται');
+
+				assert.equal(greekUtils.sanitizeDiacritics('Ἐξ οὗ καὶ δῆλον ὅτι οὐδεμία τῶν ἠθικῶν ἀρετῶν φύσει ἡμῖν ἐγγίνεται', 'Ἐ'),
+					'Ἐξ ου και δηλον οτι ουδεμια των ηθικων αρετων φυσει ημιν εγγινεται');
 
 				done();
 			});


### PR DESCRIPTION
Hey there! Awesome package! I added an optional second parameter to all functions that accepts a string with characters to not convert.

My case use for this is that I'm working on a package that searches files for greek characters and converts them to their greeklish alternatives, however when doing the replacements in Javascript files, I would like semicolons to be left alone.