### PR TITLE
replaceText() refactoring

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,19 +89,18 @@ greekUtils = {
  * @returns {String}
  */
 function replaceText(text, characterMap, exactMatch, ignore) {
-	var characters,
-		regexString,
+	var regexString,
 		regex;
 
 	exactMatch = exactMatch || false;
 
 	if (typeof text === 'string' && text.length > 0) {
-		for (characters of characterMap) {
+		characterMap.forEach(function (characters) {
 			regexString = exactMatch ? characters.find : '[' + characters.find + ']';
 			if (ignore) { regexString = '(?![' + ignore + '])' + regexString; }
 			regex = new RegExp(regexString, 'g');
 			text = text.replace(regex, characters.replace);
-		}
+		});
 	}
 
 	return text;


### PR DESCRIPTION
Tests run. All passing. 
I believe it is better this way, because it runs an all environments and setups, by default.
Otherwise, as I said, a non-Babel Webpack setup fails with the error:
`ERROR in bundle.js from UglifyJs. Unexpected token name «of», expected punc «; »`.